### PR TITLE
feat: allow textarea input in the list action

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,7 @@ The defined `:inputs` option will display a popup with a form that contains defi
 `:inputs` should be a list of maps. Each input must have a `:name` and a `:title`.
 An optional key in the input map is `:use_select`, which defaults to `false`.
 If `true`, the input becomes a `select` instead by using a passed in list called `:options`, which is a list of lists formatted like so `[[display, value], [display, value]]`.
+An optional key in the input map is `:type`. If set to `:textarea`, the input becomes a textarea instead of a text input. For textarea inputs, a `:default` value is required.
 If `false`, a `:default` value is required for the text input.
 After submitting the popup form, the extra values, along with the selected resources, are passed to the `:action` function.
 In the example above, `change_price/2` will receive the selected products with a map of extra inputs, like: `%{"new_price" => "3.5"}` for example.

--- a/README.md
+++ b/README.md
@@ -919,8 +919,8 @@ The defined `:inputs` option will display a popup with a form that contains defi
 `:inputs` should be a list of maps. Each input must have a `:name` and a `:title`.
 An optional key in the input map is `:use_select`, which defaults to `false`.
 If `true`, the input becomes a `select` instead by using a passed in list called `:options`, which is a list of lists formatted like so `[[display, value], [display, value]]`.
-An optional key in the input map is `:type`. If set to `:textarea`, the input becomes a textarea instead of a text input. For textarea inputs, a `:default` value is required.
-If `false`, a `:default` value is required for the text input.
+An optional key in the input map is `:type`. If set to `:textarea`, the input becomes a textarea instead of a text input. For textarea inputs, a `:rows` value is optional and configures the amount of rows.
+An optional key `:default` can be configured for textarea and text input, which defines the default value for this field.
 After submitting the popup form, the extra values, along with the selected resources, are passed to the `:action` function.
 In the example above, `change_price/2` will receive the selected products with a map of extra inputs, like: `%{"new_price" => "3.5"}` for example.
 

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -124,19 +124,19 @@
                       <div class="form-group">
                         <%= cond do %>
                           <% Map.has_key?(extra, :use_select) && extra.use_select -> %>
-                          <% Map.has_key?(extra, :type) && extra.type == :select -> %>
+                          <% Map.get(extra, :type) == :select -> %>
                             <label><%= extra.title %></label>
                             <select data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" class="form-select w-100 kaffy-list-action-input">
                               <%= for [text, value] <- extra.options do %>
                                 <option value="<%= value %>"><%= text %></option>
                               <% end %>
                             </select>
-                          <% Map.has_key?(extra, :type) && extra.type == :textarea -> %>
+                          <% Map.get(extra, :type) == :textarea -> %>
                             <label><%= extra.title %></label>
-                            <textarea name="kaffy-input[<%= extra.name %>]" class="form-control kaffy-list-action-input" rows="4"><%= extra.default %></textarea>
+                            <textarea name="kaffy-input[<%= extra.name %>]" class="form-control kaffy-list-action-input" rows="<%= Map.get(extra, :rows, 4) %>"><%= Map.get(extra, :default, "") %></textarea>
                           <% true -> %>
                             <label><%= extra.title %></label>
-                            <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= extra.default %>" class="form-control kaffy-list-action-input" />
+                            <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= Map.get(extra, :default, "") %>" class="form-control kaffy-list-action-input" />
                         <% end %>
                       </div>
                     <% end %>

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -122,16 +122,21 @@
                   <div class="modal-body">
                     <%= for extra <- extra_inputs do %>
                       <div class="form-group">
-                        <%= if Map.has_key?(extra, :use_select) && extra.use_select do %>
-                          <label><%= extra.title %></label>
-                          <select data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" class="form-select w-100 kaffy-list-action-input">
-                            <%= for [text, value] <- extra.options do %>
-                              <option value="<%= value %>"><%= text %></option>
-                            <% end %>
-                          </select>
-                        <% else %>
-                          <label><%= extra.title %></label>
-                          <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= extra.default %>" class="form-control kaffy-list-action-input" />
+                        <%= cond do %>
+                          <% Map.has_key?(extra, :use_select) && extra.use_select -> %>
+                          <% Map.has_key?(extra, :type) && extra.type == :select -> %>
+                            <label><%= extra.title %></label>
+                            <select data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" class="form-select w-100 kaffy-list-action-input">
+                              <%= for [text, value] <- extra.options do %>
+                                <option value="<%= value %>"><%= text %></option>
+                              <% end %>
+                            </select>
+                          <% Map.has_key?(extra, :type) && extra.type == :textarea -> %>
+                            <label><%= extra.title %></label>
+                            <textarea name="kaffy-input[<%= extra.name %>]" class="form-control kaffy-list-action-input" rows="4"><%= extra.default %></textarea>
+                          <% true -> %>
+                            <label><%= extra.title %></label>
+                            <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= extra.default %>" class="form-control kaffy-list-action-input" />
                         <% end %>
                       </div>
                     <% end %>


### PR DESCRIPTION
Currently, only input fields and select fields can be rendered in the list action. With this PR, a new key `:type` is introduced, which right now can only be `:select` (which has the same effect as the optional key `:use_select`) or `:textarea`, which renders a 4 column text area.

A few considerations:

- Maybe the rows and columns should be configurable via optional keys?
- I kept `use_select` for backwards compability, but if we introduce new types, it would make more sense to not use `use_select` anymore.