### PR TITLE
chore: add option :value to the form_fields function

### DIFF
--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -78,7 +78,7 @@ defmodule Kaffy.ResourceAdmin do
 
   Supported options are:
 
-  `:label`, `:type`, `:choices`, and `:permission`
+  `:label`, `:type`, `:choices`, `:permission`, and `:value`
 
   `:type` can be any ecto type in addition to `:file` and `:textarea`
 
@@ -86,6 +86,9 @@ defmodule Kaffy.ResourceAdmin do
   the field will be rendered as a `<select>` element regardless of the actual field type.
 
   Setting `:permission` to `:read` will make the field non-editable. It is `:write` by default.
+
+  The `:value` option can be a function that takes the schema instance and returns the initial value
+  for the field. This is useful for setting default values or computed values.
 
   If you want to remove a field from being rendered, just remove it from the list.
 
@@ -102,7 +105,13 @@ defmodule Kaffy.ResourceAdmin do
       image: %{type: :file},
       status: %{choices: [{"Pending", "pending"}, {"Published", "published"}]},
       body: %{type: :textarea, rows: 3},
-      views: %{permission: :read}
+      views: %{permission: :read},
+      company_id: %{
+        label: "Company",
+        type: :select,
+        choices: company_choices(),
+        value: fn schema -> get_default_company_id(schema) end
+      }
     ]
   end
   ```

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -69,7 +69,8 @@ defmodule Kaffy.ResourceSchema do
       update: :editable,
       label: nil,
       type: nil,
-      choices: nil
+      choices: nil,
+      value: nil
     }
 
     Map.merge(default, options || %{})


### PR DESCRIPTION
## Current behavior

Currently the form_fields function in kaffy allows passing the values that will be shown for a specific resource. However, if the view for the resource differs from the schema specification, there is no way to display the initial value from the DB.

## Expected behavior

With this change, all existent form_fields values should still work, but new ones can use a :value option that takes a function as parameter. The function receives the schema and outputs the desired initial value.


### Before the change
https://github.com/user-attachments/assets/8dba50ef-cf14-478f-a418-a9d78fcf420c

### After the change

https://github.com/user-attachments/assets/cfd4db11-6452-4bea-aca5-a5e63ba7b56c


 